### PR TITLE
Clarifications between app and bootloader binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This example shows how to create a bootloader.
 To read more about the bootloader, please visit [bootloader tutorial](https://docs.mbed.com/docs/mbed-os-handbook/en/latest/advanced/bootloader/).
 
 ## Required hardware
-* A supported board - [u-blox EVK-ODIN-W2](https://developer.mbed.org/platforms/ublox-EVK-ODIN-W2/), [Nucleo F429ZI](https://developer.mbed.org/platforms/ST-Nucleo-F429ZI/) or [K64F](https://developer.mbed.org/platforms/FRDM-K64F/).
-* CI test shield.
+* A supported target - [u-blox EVK-ODIN-W2](https://developer.mbed.org/platforms/ublox-EVK-ODIN-W2/), [Nucleo F429ZI](https://developer.mbed.org/platforms/ST-Nucleo-F429ZI/) or [K64F](https://developer.mbed.org/platforms/FRDM-K64F/).
 * SD card.
+* (If no onboard SD card port is present) Shield or breakout board connecting the SD card to the SPI pins.
 
 ## Import the example application
 
@@ -18,11 +18,40 @@ mbed import mbed-os-example-bootloader
 cd mbed-os-example-bootloader
 ```
 
-## Set up application to be a bootloader
+## Connecting the SD card
+This example is configured to use the **onboard SD card port** for the K64F and the UBLOX_EVK_ODIN_W2.
 
-All supported boards mentioned above are set up to build as a bootloader image. To add support for a new board, you must specify the size of the bootloader.
+For other targets, the following Arduino form-factor SPI pins are used by default:
+- `D11` - `MOSI`
+- `D12` - `MISO`
+- `D13` - `SCK`
+- `D10` - `CS`
 
-To do this, set the target (replace `<TARGET_NAME>` with your target name) value `restrict_size` to the maximum bootloader size in mbed_app.json:
+
+To use different SPI pins, you will need to modify the `mbed_app.json` file. Add a key for your target to the `target_overrides` section with the following data (replace `<TARGET_NAME>` with your target's name):
+
+```
+{
+    ...
+    "target_overrides": {
+        ...
+        "<TARGET_NAME>": {
+            "sd_card_mosi": "<MOSI_PIN>",
+            "sd_card_miso": "<MISO_PIN>",
+            "sd_card_sck": "<SCK_PIN>",
+            "sd_card_cs": "<CS_PIN>"
+        }
+        ...
+    }
+    ...
+}
+```
+
+## Preparing the bootloader
+
+All supported targets mentioned above are set up to build as a bootloader image. To add support for a new target, you must specify the size of the bootloader.
+
+To do this, set the target value `restrict_size` to the maximum bootloader size in `mbed_app.json` (replace `<TARGET_NAME>` with your target name):
 
 ```
     "target_overrides": {
@@ -33,11 +62,11 @@ To do this, set the target (replace `<TARGET_NAME>` with your target name) value
         ...
 ```
 
-Note - `restrict_size` pads the build image to the requested size.
+<span class="tips">**Note:** `restrict_size` pads the build image to the requested size.</span>
 
-## Now compile
+## Building
 
-Invoke `mbed compile`, and specify the name of your platform and your favorite toolchain (`GCC_ARM`, `ARM`, `IAR`). For example, for the ARM Compiler 5:
+Invoke `mbed compile`, and specify the name of your target and your favorite toolchain (`GCC_ARM`, `ARM`, `IAR`). For example, for the ARM Compiler 5:
 
 ```
 mbed compile -m <TARGET_NAME> -t ARM
@@ -74,45 +103,53 @@ Total Flash memory (text + data + misc): 60554 bytes
 Image: .\BUILD\<TARGET_NAME>\ARM\mbed-os-example-bootloader.bin
 ```
 
-It creates two binary files. The original uncombined image is in the output directory, <project-name>_application.bin, and the bootloader image is <project-name>.bin.
+After the build completes, the build system saves two binary images in the `BUILD/<TARGET_NAME>/<TOOLCHAIN_NAME>` directory. The original unpadded image is saved with the name `<project-name>_application.bin`. The padded bootloader image (used for combining with applications) is saved with the name `<project-name>.bin`.
 
-When the build succeeds, you have created a bootloader for your target. This bootloader defines the update file to be located at `/sd/mbed-os-example-bootloader-blinky_application.bin`. This is the binary bootloader flashes and then jumps to.
+In this example, the update binary for the bootloader is defined in `main.cpp`  as `mbed-os-example-bootloader-blinky_application.bin` (specified under the macro `UPDATE_FILE`). The bootloader will look for this file in the root of the SD card, flash it to memory, and then jump to the application.
 
 ## Set up application to use bootloader
 
-The next step is to build an application you can combine with your bootloader to create a loadable image. 
+The next step is to build an application you can combine with your bootloader to create a loadable image. Any application works; however, you may wish to start with the [Blinky example](https://github.com/ARMmbed/mbed-os-example-blinky).
 
-1. Update your board to use the newly created bootloader image. To do this, set the target (replace `<TARGET_NAME>` with your target name) value `bootloader_img` to the file path of the bootloader image.
+1. Instruct the build system to use the newly created padded bootloader image (named `<project-name>.bin` in the previous section). To do this, create a `target_overrides` section in your application's `mbed_app.json` file and add a key for your target (see `<TARGET_NAME>` in the example below). If `mbed_app.json` does not already exist in your application, create one.
+
+2. Set the target value `bootloader_img` in `mbed_app.json` to the file path of the padded bootloader image . For the below example, copy the padded bootloader image to the project directory.
 
 ```
+{
     "target_overrides": {
         ...
         "<TARGET_NAME>": {
-            "target.bootloader_img": "bootloader/<TARGET_NAME>.bin"
+            "target.bootloader_img": "<path to padded bootloader binary>"
         },
         ...
+}
 ```
 
-2. Invoke `mbed compile`, and specify the name of your platform and the toolchain you are using (`GCC_ARM`, `ARM`, `IAR`). For example, for the ARM Compiler 5:
+2. Invoke `mbed compile`, and specify the name of your target and the toolchain you are using (`GCC_ARM`, `ARM`, `IAR`). For example, for the ARM Compiler 5:
 
     ```
     mbed compile -m <TARGET_NAME> -t ARM
     ```
 
+After the build completes, the build system saves two binary images in the `BUILD/<TARGET_NAME>/<TOOLCHAIN_NAME>` directory. The image that contains the combined bootloader and application (suitable for flashing to the device's ROM directly) is named `<project-name>.bin`. Use the image saved with the name `<project-name>_application.bin` as the update binary (the one you place on the SD card).
+
 ### Program bootloader and application
 
 1. Connect your mbed device to the computer over USB.
-1. Copy the application binary file to the mbed device.
+1. Copy the combined bootloader and application binary file (named `<project-name>.bin` in the previous section) to the mbed device.
 1. Press the reset button to start the program.
 
 ### Program application using SD card
 
+<span class="tips">**Note:** You must first flash the combined bootloader and application image or just the bootloader image (padded or unpadded) before proceeding with the following steps.</span>
+
 1. Connect the SD card to your computer.
-1. Copy the application binary to the root of the SD card.
-1. Remove the SD card from your PC, and plug it into the mbed board.
+1. Copy the update application binary (named `<project-name>_application.bin` in the previous section) to the root of the SD card.
+1. Remove the SD card from your PC, and connect it to your mbed (see the above section [Setting up the SD card](#setting-up-the-sd-card))
 1. Press the reset button to start the firmware update.
 
-If a terminal is open, the following prints:
+If a terminal is open, the following should print out at a baud rate of 9600:
 
 ```
 Firmware update found

--- a/main.cpp
+++ b/main.cpp
@@ -2,10 +2,13 @@
 #include "SDBlockDevice.h"
 #include "FATFileSystem.h"
 
-#define UPDATE_FILE     "/sd/mbed-os-example-bootloader-blinky_application.bin"
+#define SD_MOUNT_PATH           "sd"
+#define FULL_UPDATE_FILE_PATH   "/" SD_MOUNT_PATH "/" MBED_CONF_APP_UPDATE_FILE
 
-SDBlockDevice sd(D11, D12, D13, D10);
-FATFileSystem fs("sd");
+//Pin order: MOSI, MISO, SCK, CS
+SDBlockDevice sd(MBED_CONF_APP_SD_CARD_MOSI, MBED_CONF_APP_SD_CARD_MISO,
+                 MBED_CONF_APP_SD_CARD_SCK, MBED_CONF_APP_SD_CARD_CS);
+FATFileSystem fs(SD_MOUNT_PATH);
 FlashIAP flash;
 
 void apply_update(FILE *file, uint32_t address);
@@ -15,14 +18,14 @@ int main()
     sd.init();
     fs.mount(&sd);
 
-    FILE *file = fopen(UPDATE_FILE, "rb");
+    FILE *file = fopen(FULL_UPDATE_FILE_PATH, "rb");
     if (file != NULL) {
         printf("Firmware update found\r\n");
 
         apply_update(file, POST_APPLICATION_ADDR);
 
         fclose(file);
-        remove(UPDATE_FILE);
+        remove(FULL_UPDATE_FILE_PATH);
     } else {
         printf("No update found to apply\r\n");
     }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,13 +1,40 @@
 {
+    "config": {
+        "update_file": {
+            "help": "Path to the application update binary on the SD card",
+            "value": "\"mbed-os-example-blinky_application.bin\""
+        },
+        "sd_card_mosi": {
+            "help": "MCU pin connected to the SD card's SPI MOSI pin",
+            "value": "D11"
+        },
+        "sd_card_miso": {
+            "help": "MCU pin connected to the SD card's SPI MISO pin",
+            "value": "D12"
+        },
+        "sd_card_sck": {
+            "help": "MCU pin connected to the SD card's SPI SCK pin",
+            "value": "D13"
+        },
+        "sd_card_cs": {
+            "help": "MCU pin connected to the SD card's SPI CS pin",
+            "value": "D10"
+        }
+    },
     "target_overrides": {
         "K64F": {
-            "target.restrict_size": "0x20000"
+            "target.restrict_size": "0x20000",
+            "sd_card_mosi": "D11",
+            "sd_card_miso": "D12",
+            "sd_card_sck": "D13",
+            "sd_card_cs": "D10"
         },
         "NUCLEO_F429ZI": {
             "target.restrict_size": "0x20000"
         },
         "UBLOX_EVK_ODIN_W2": {
-            "target.restrict_size": "0x20000"
+            "target.restrict_size": "0x20000",
+            "sd_card_cs": "D9"
         }
     }
 }


### PR DESCRIPTION
**NOTE:** I'm currently submitting this against the `mbed-os-5.5.0-rc1-oob` branch since that's what I was testing. If I should submit this against `master` instead please let me know.

This attempts to clarify a few vague points in the README. It helps to
distinguish between the different binaries created during the bootloader
building process.

I also moved a few parenthesized phrases ([you're darn right that's a real word](https://www.merriam-webster.com/dictionary/parenthesize)) to the ends of sentences. When I read them they broke up the sentence too much and made them hard to understand.

@c1728p9 Can you make sure I didn't mess up the jargon here? Specifically, I swapped the word "combined" with "padded/unpadded" when building the bootloader binaries. I think that's right, though not 100% sure.

@AnotherButler A general English sanity check would be much appreciated 😄 And probably my use of the `tips` tag.