### PR TITLE
Fixing rebase issue in config

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -36,8 +36,5 @@
             "target.restrict_size": "0x40000",
             "sd_card_cs": "D9"
         }
-    },
-    "config": {
-        "update_file": "\"/sd/mbed-os-example-blinky_application.bin\""
     }
 }


### PR DESCRIPTION
On the master branch there is currently two entries for `config` in `mbed_app.json`, which causes compilation to fail! This should fix it.

@0xc0170 @c1728p9 @theotherjimmy 