### PR TITLE
remove unused parameters from printf call.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -90,7 +90,7 @@ void apply_update(FILE *file, uint32_t address)
             }
         }
     }
-    printf("Flashed 100%%\r\n", ftell(file), len);
+    printf("Flashed 100%%\r\n");
 
     delete[] page_buffer;
 


### PR DESCRIPTION
These unused parameters make GCC yell
```
[Warning] main.cpp@93,49: too many arguments for format [-Wformat-extra-args]
```