### PR TITLE
Fix linker errors due to a duplicate SD driver

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -22,6 +22,9 @@
         }
     },
     "target_overrides": {
+        "*": {
+            "target.components_remove": ["SD"]
+        },
         "K64F": {
             "target.restrict_size": "0x40000",
             "sd_card_mosi": "PTE3",


### PR DESCRIPTION
Remove the SD component for all targets since this repo is part of mbed-os-example-bootloader. This allows this example to work with both mbed-os version 5.9 and 5.10.