### PR TITLE
Example should now work with SD component

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -22,9 +22,6 @@
         }
     },
     "target_overrides": {
-        "*": {
-            "target.components_remove": ["SD"]
-        },
         "K64F": {
             "target.restrict_size": "0x40000",
             "sd_card_mosi": "PTE3",
@@ -33,9 +30,11 @@
             "sd_card_cs": "PTE4"
         },
         "NUCLEO_F429ZI": {
+            "target.components_add": ["SD"],
             "target.restrict_size": "0x40000"
         },
         "UBLOX_EVK_ODIN_W2": {
+            "target.components_add": ["SD"],
             "target.restrict_size": "0x40000",
             "sd_card_cs": "D9"
         }

--- a/sd-driver.lib
+++ b/sd-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/sd-driver/#a8c85d30af86a7431d85dee02d133d60dd386406


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
We are adding get_type to SDBlockDevice and the external sd-driver repo is deprecated. therefore I like to update the example to work with SDBlockDevice component which is part of mebd-os.
Currently, Travis is failing for the mbed-os PR #9135 and PR #9136 and after this change, they should pass.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

