### PR TITLE
Set sd-driver to point to new version sd-driver-0.0.4-mbed-os-5.4.1

### DIFF
--- a/sd-driver.lib
+++ b/sd-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/sd-driver/#a8c85d30af86a7431d85dee02d133d60dd386406
+https://github.com/ARMmbed/sd-driver/#a38427be2e3184bfadc305fc4525f9224426078a


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Pointing sd-driver to a new intermediate version sd-driver-0.0.4-mbed-os-5.4.1. 
this is due to the addon of get_type method to all block devices in mbed-os which brake the external sd-driver repo and therefore had to be fixed.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

